### PR TITLE
allow COLLATE keyword at CREATE TABLE

### DIFF
--- a/src/RegExpPattern.php
+++ b/src/RegExpPattern.php
@@ -36,6 +36,7 @@ class RegExpPattern
         $pattern .= '(?:\s+ENGINE=(?<engine>[^;\s]+))?\s*';
         $pattern .= '(?:AUTO_INCREMENT=(?<autoIncrement>\d+))?\s*';
         $pattern .= '(?:DEFAULT CHARSET=(?<defaultCharset>[^;\s]+))?\s*)';
+        $pattern .= '(?:COLLATE=.+?)?\s*';
         $pattern .= '(?:\/\*.+?\*\/)?\s*';
         $pattern .= ';/';
         $pattern .= 's'; // modifier


### PR DESCRIPTION
Needed to make it work with mysqldump[s] created from newer versions of mysql (5.6.x here)