### PR TITLE
Column with '' or ; or / in comments not handled correctly

### DIFF
--- a/src/RegExpPattern.php
+++ b/src/RegExpPattern.php
@@ -11,7 +11,7 @@ class RegExpPattern
         'binary',
         'real',
         'decimal\((?<decimalLength>\d+),(?<decimalPrecision>\d+)\)',
-        'double(?:\((?<doubleLength>\d+),(?<doublePrecision>\d+)\))?',
+        'double(?:\s+unsigned)?(?:\((?<doubleLength>\d+),(?<doublePrecision>\d+)\))?',
         'datetime',
         'date',
         'time',

--- a/src/RegExpPattern.php
+++ b/src/RegExpPattern.php
@@ -35,7 +35,8 @@ class RegExpPattern
     public static function tables()
     {
         $pattern = '/(?<creationScript>CREATE\s+TABLE\s+`(?<tableName>\S+)`\s+';
-        $pattern .= '\((?<tableDefinition>([^;\/]+?(.COMMENT.\'[^\']+((\'\')[^\']*)*\'(?!=\')))+.*?|[^;\/]+?)\)';
+        $pattern .= '\((?<tableDefinition>([^;\/]+?';
+        $pattern .=     '(.COMMENT.\'[^\']+((\'\')[^\']*)*\'(?!=\')))+.*?|[^;\/]+?)\)';
         $pattern .= '(?:\s+ENGINE=(?<engine>[^;\s]+))?\s*';
         $pattern .= '(?:AUTO_INCREMENT=(?<autoIncrement>\d+))?\s*';
         $pattern .= '(?:DEFAULT CHARSET=(?<defaultCharset>[^;\s]+))?\s*)';

--- a/src/RegExpPattern.php
+++ b/src/RegExpPattern.php
@@ -2,6 +2,9 @@
 
 namespace Camcima\MySqlDiff;
 
+/*
+* Thanks to http://stackoverflow.com/users/588916/collapsar, http://stackoverflow.com/a/36933805/123594
+*/
 
 class RegExpPattern
 {
@@ -32,7 +35,7 @@ class RegExpPattern
     public static function tables()
     {
         $pattern = '/(?<creationScript>CREATE\s+TABLE\s+`(?<tableName>\S+)`\s+';
-        $pattern .= '\((?<tableDefinition>[^;\/]+)\)';
+        $pattern .= '\((?<tableDefinition>([^;\/]+?(.COMMENT.\'[^\']+((\'\')[^\']*)*\'(?!=\')))+.*?|[^;\/]+?)\)';
         $pattern .= '(?:\s+ENGINE=(?<engine>[^;\s]+))?\s*';
         $pattern .= '(?:AUTO_INCREMENT=(?<autoIncrement>\d+))?\s*';
         $pattern .= '(?:DEFAULT CHARSET=(?<defaultCharset>[^;\s]+))?\s*)';

--- a/src/RegExpPattern.php
+++ b/src/RegExpPattern.php
@@ -58,7 +58,7 @@ class RegExpPattern
         $pattern .= '(?<autoIncrement>AUTO_INCREMENT)?\s*';
         $pattern .= '(?:DEFAULT (?<defaultValue>\S+|\'[^\']+\'))?\s*';
         $pattern .= '(?:ON UPDATE (?<onUpdateValue>\S+))?\s*';
-        $pattern .= '(?:COMMENT \'(?<comment>[^\']+)\')?\s*';
+        $pattern .= '(?:COMMENT \'(?<comment>([^\']+|\'\'))\')?\s*';
         $pattern .= '(?:,|$)/';
 
         return $pattern;


### PR DESCRIPTION
```
CREATE TABLE IF NOT EXISTS `jos_ucm_history` (
  `version_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `ucm_item_id` int(10) unsigned NOT NULL,
  `ucm_type_id` int(10) unsigned NOT NULL,
  `version_note` varchar(255) NOT NULL DEFAULT '' COMMENT 'Optional version name',
  `save_date` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
  `editor_user_id` int(10) unsigned NOT NULL DEFAULT '0',
  `character_count` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Number of characters in this version.',
  `sha1_hash` varchar(50) NOT NULL DEFAULT '' COMMENT 'SHA1 hash of the version_data column.',
  `version_data` mediumtext NOT NULL COMMENT 'json-encoded string of version data',
  `keep_forever` tinyint(4) NOT NULL DEFAULT '0' COMMENT '0=auto delete; 1=keep',
  PRIMARY KEY (`version_id`),
  KEY `idx_ucm_item_id` (`ucm_type_id`,`ucm_item_id`),
  KEY `idx_save_date` (`save_date`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=1 ;
```