### PR TITLE
Added some features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 php:
   - '5.6'

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -5,6 +5,11 @@ namespace Camcima\MySqlDiff\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * Class AbstractCommand
+ *
+ * @package Camcima\MySqlDiff\Command
+ */
 abstract class AbstractCommand extends Command
 {
     /**
@@ -30,11 +35,11 @@ abstract class AbstractCommand extends Command
 
     /**
      * @param string $string
-     * @param bool $forceOuput
+     * @param bool $forceOutput
      */
-    protected function outputString($string = '', $forceOuput = false)
+    protected function outputString($string = '', $forceOutput = false)
     {
-        if ($this->verbose || $forceOuput) {
+        if ($this->verbose || $forceOutput) {
             $this->output->write($string);
         }
     }

--- a/src/Command/DiffCommand.php
+++ b/src/Command/DiffCommand.php
@@ -9,6 +9,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * Class DiffCommand
+ *
+ * @package Camcima\MySqlDiff\Command
+ */
 class DiffCommand extends AbstractCommand
 {
     protected function configure()
@@ -38,6 +43,7 @@ class DiffCommand extends AbstractCommand
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
+     * @return int|null|void
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -9,6 +9,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * Class MigrateCommand
+ *
+ * @package Camcima\MySqlDiff\Command
+ */
 class MigrateCommand extends AbstractCommand
 {
     protected function configure()
@@ -50,6 +55,7 @@ class MigrateCommand extends AbstractCommand
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
+     * @return int|null|void
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Differ.php
+++ b/src/Differ.php
@@ -252,7 +252,6 @@ class Differ
 
         $migrationScript[] = '';
         $migrationScript[] = '# Changed Tables';
-        $migrationScript[] = '';
         foreach ($databaseDiff->getChangedTables() as $changedTable) {
             $migrationScript[] = '';
             $migrationScript[] = sprintf('-- changed table `%s`', $changedTable->getName());
@@ -266,7 +265,6 @@ class Differ
         }
         $migrationScript[] = '';
         $migrationScript[] = '# New Tables';
-        $migrationScript[] = '';
 
         foreach ($databaseDiff->getNewTables() as $newTable) {
             $migrationScript[] = '';
@@ -282,8 +280,8 @@ class Differ
 
         $migrationScript[] = '';
         $migrationScript[] = '# Disable Foreign Keys Check';
-        $migrationScript[] = '';
         $migrationScript[] = 'SET FOREIGN_KEY_CHECKS = 1;';
+        $migrationScript[] = '';
 
         return $migrationScript;
     }

--- a/src/Differ.php
+++ b/src/Differ.php
@@ -7,6 +7,11 @@ use Camcima\MySqlDiff\Model\Column;
 use Camcima\MySqlDiff\Model\Database;
 use Camcima\MySqlDiff\Model\DatabaseDiff;
 
+/**
+ * Class Differ
+ *
+ * @package Camcima\MySqlDiff
+ */
 class Differ
 {
     /**
@@ -32,7 +37,8 @@ class Differ
             }
 
             $toTable = $toDatabase->getTableByName($fromTable->getName());
-            if ($fromTable->generateCreationScript(true) != $toTable->generateCreationScript(true)) {
+
+            if ($fromTable->generateCreationScript(true) !== $toTable->generateCreationScript(true)) {
                 $changedTable = new ChangedTable($fromTable, $toTable);
                 $this->diffChangedTable($changedTable);
                 $databaseDiff->addChangedTable($changedTable);
@@ -89,18 +95,19 @@ class Differ
 
             // Determine changed columns
             $fromColumn = $fromTable->getColumnByName($toColumn->getName());
-            if ($toColumn->generateCreationScript() != $fromColumn->generateCreationScript()) {
+            if ($toColumn->generateCreationScript() !== $fromColumn->generateCreationScript()) {
                 $changedTable->addChangedColumn($toColumn);
                 continue;
             }
 
             if (!$fromColumn->getPreviousColumn() && !$toColumn->getPreviousColumn()) {
                 continue;
-            } elseif (!$fromColumn->getPreviousColumn() && $toColumn->getPreviousColumn() instanceof Column) {
+            }
+            if (!$fromColumn->getPreviousColumn() && $toColumn->getPreviousColumn() instanceof Column) {
                 $this->addChangedColumn($changedTable, $toColumn);
             } elseif ($fromColumn->getPreviousColumn() instanceof Column && !$toColumn->getPreviousColumn()) {
                 $this->addChangedColumn($changedTable, $toColumn);
-            } elseif ($fromColumn->getPreviousColumn()->getName() != $toColumn->getPreviousColumn()->getName()) {
+            } elseif ($fromColumn->getPreviousColumn()->getName() !== $toColumn->getPreviousColumn()->getName()) {
                 $this->addChangedColumn($changedTable, $toColumn);
             }
         }
@@ -137,7 +144,7 @@ class Differ
             return;
         }
 
-        if ($fromTable->generatePrimaryKeyCreationScript() != $toTable->generatePrimaryKeyCreationScript()) {
+        if ($fromTable->generatePrimaryKeyCreationScript() !== $toTable->generatePrimaryKeyCreationScript()) {
             $changedTable->setChangedPrimaryKeys($toTable->getPrimaryKeys());
         }
     }
@@ -167,7 +174,7 @@ class Differ
 
             // Determine changed indexes
             $fromIndex = $fromTable->getIndexByName($toIndex->getName());
-            if ($toIndex->generateCreationScript() != $fromIndex->generateCreationScript()) {
+            if ($toIndex->generateCreationScript() !== $fromIndex->generateCreationScript()) {
                 $changedTable->addChangedIndex($toIndex);
             }
         }
@@ -198,7 +205,7 @@ class Differ
 
             // Determine changed foreign keys
             $fromForeignKey = $fromTable->getForeignKeyByName($toForeignKey->getName());
-            if ($toForeignKey->generateCreationScript() != $fromForeignKey->generateCreationScript()) {
+            if ($toForeignKey->generateCreationScript() !== $fromForeignKey->generateCreationScript()) {
                 $changedTable->addChangedForeignKey($toForeignKey);
             }
         }
@@ -212,46 +219,71 @@ class Differ
      */
     public function generateMigrationScript(DatabaseDiff $databaseDiff, $displayProgress = false)
     {
-        $migrationScript = '';
-        $migrationScript .= '# Disable Foreign Keys Check' . PHP_EOL;
-        $migrationScript .= 'SET FOREIGN_KEY_CHECKS = 0;' . PHP_EOL;
-        $migrationScript .= 'SET SQL_MODE = \'\';' . PHP_EOL;
+        return implode(PHP_EOL, $this->generateMigrationScriptArray($databaseDiff, $displayProgress));
+    }
 
-        $migrationScript .= PHP_EOL . '# Deleted Tables' . PHP_EOL;
+    /**
+     * @param DatabaseDiff $databaseDiff
+     * @param bool $displayProgress
+     *
+     * @return array
+     */
+    public function generateMigrationScriptArray(DatabaseDiff $databaseDiff, $displayProgress = false)
+    {
+        $migrationScript = array();
+        $migrationScript[] = '# Disable Foreign Keys Check';
+        $migrationScript[] = 'SET FOREIGN_KEY_CHECKS = 0;';
+        $migrationScript[] = 'SET SQL_MODE = \'\';';
+
+        $migrationScript[] = '';
+        $migrationScript[] = '# Deleted Tables';
         foreach ($databaseDiff->getDeletedTables() as $deletedTable) {
-            $migrationScript .= PHP_EOL . sprintf('-- deleted table `%s`' . PHP_EOL . PHP_EOL, $deletedTable->getName());
+            $migrationScript[] = '';
+            $migrationScript[] = sprintf('-- deleted table `%s`', $deletedTable->getName());
+            $migrationScript[] = '';
+
 
             if ($displayProgress) {
-                $migrationScript .= sprintf("SELECT 'Dropping table %s';" . PHP_EOL, $deletedTable->getName());
+                $migrationScript[] = sprintf("SELECT 'Dropping table %s';", $deletedTable->getName());
             }
 
-            $migrationScript .= sprintf('DROP TABLE `%s`;' . PHP_EOL, $deletedTable->getName());
+            $migrationScript[] = sprintf('DROP TABLE `%s`;', $deletedTable->getName());
         }
 
-        $migrationScript .= PHP_EOL . '# Changed Tables' . PHP_EOL;
+        $migrationScript[] = '';
+        $migrationScript[] = '# Changed Tables';
+        $migrationScript[] = '';
         foreach ($databaseDiff->getChangedTables() as $changedTable) {
-            $migrationScript .= PHP_EOL . sprintf('-- changed table `%s`' . PHP_EOL . PHP_EOL, $changedTable->getName());
+            $migrationScript[] = '';
+            $migrationScript[] = sprintf('-- changed table `%s`', $changedTable->getName());
+            $migrationScript[] = '';
 
             if ($displayProgress) {
-                $migrationScript .= sprintf("SELECT 'Altering table %s';" . PHP_EOL, $changedTable->getName());
+                $migrationScript[] = sprintf("SELECT 'Altering table %s';", $changedTable->getName());
             }
 
-            $migrationScript .= $changedTable->generateAlterScript() . PHP_EOL;
+            $migrationScript[] = $changedTable->generateAlterScript();
         }
+        $migrationScript[] = '';
+        $migrationScript[] = '# New Tables';
+        $migrationScript[] = '';
 
-        $migrationScript .= PHP_EOL . '# New Tables' . PHP_EOL;
         foreach ($databaseDiff->getNewTables() as $newTable) {
-            $migrationScript .= PHP_EOL . sprintf('-- new table `%s`' . PHP_EOL . PHP_EOL, $newTable->getName());
+            $migrationScript[] = '';
+            $migrationScript[] = sprintf('-- new table `%s`', $newTable->getName());
+            $migrationScript[] = '';
 
             if ($displayProgress) {
-                $migrationScript .= sprintf("SELECT 'Creating table %s';" . PHP_EOL, $newTable->getName());
+                $migrationScript[] = sprintf("SELECT 'Creating table %s';", $newTable->getName());
             }
 
-            $migrationScript .= $newTable->generateCreationScript(true) . PHP_EOL;
+            $migrationScript[] = $newTable->generateCreationScript(true);
         }
 
-        $migrationScript .= PHP_EOL . '# Disable Foreign Keys Check' . PHP_EOL;
-        $migrationScript .= 'SET FOREIGN_KEY_CHECKS = 1;' . PHP_EOL;
+        $migrationScript[] = '';
+        $migrationScript[] = '# Disable Foreign Keys Check';
+        $migrationScript[] = '';
+        $migrationScript[] = 'SET FOREIGN_KEY_CHECKS = 1;';
 
         return $migrationScript;
     }

--- a/src/Model/ChangedTable.php
+++ b/src/Model/ChangedTable.php
@@ -2,6 +2,11 @@
 
 namespace Camcima\MySqlDiff\Model;
 
+/**
+ * Class ChangedTable
+ *
+ * @package Camcima\MySqlDiff\Model
+ */
 class ChangedTable
 {
     /**
@@ -365,6 +370,26 @@ class ChangedTable
 
         foreach ($this->newForeignKeys as $newForeignKey) {
             $tableChanges[] = sprintf('ADD %s', $newForeignKey->generateCreationScript());
+        }
+
+        if ($this->fromTable->getEngine() !== $this->toTable->getEngine()) {
+            $tableChanges[] = sprintf('ENGINE=%s', $this->toTable->getEngine());
+        }
+
+        if ($this->fromTable->getDefaultCharset() !== $this->toTable->getDefaultCharset()) {
+            $tableChanges[] = sprintf('DEFAULT CHARSET=%s', $this->toTable->getDefaultCharset());
+        }
+
+        if ($this->fromTable->getRowFormat() !== $this->toTable->getRowFormat()) {
+            $tableChanges[] = sprintf('ROW_FORMAT=%s', $this->toTable->getRowFormat());
+        }
+
+        if ($this->fromTable->getKeyBlockSize() !== $this->toTable->getKeyBlockSize()) {
+            $tableChanges[] = sprintf('KEY_BLOCK_SIZE=%s', $this->toTable->getKeyBlockSize());
+        }
+
+        if ($this->fromTable->getComment() !== $this->toTable->getComment()) {
+            $tableChanges[] = sprintf('COMMENT=\'%s\'', str_replace('\'','\'\'', $this->toTable->getComment()));
         }
 
         $alterScript = sprintf('ALTER TABLE `%s`%s  %s;', $this->getName(), PHP_EOL, implode(',' . PHP_EOL . '  ', $tableChanges));

--- a/src/Model/Column.php
+++ b/src/Model/Column.php
@@ -2,6 +2,11 @@
 
 namespace Camcima\MySqlDiff\Model;
 
+/**
+ * Class Column
+ *
+ * @package Camcima\MySqlDiff\Model
+ */
 class Column
 {
     /**
@@ -420,7 +425,7 @@ class Column
 
         if (!$this->nullable) {
             $columnOptions[] = 'NOT NULL';
-        } elseif ($this->columnType == 'timestamp') {
+        } elseif ($this->columnType === 'timestamp') {
             $columnOptions[] = 'NULL';
         }
 

--- a/src/Model/Database.php
+++ b/src/Model/Database.php
@@ -2,6 +2,11 @@
 
 namespace Camcima\MySqlDiff\Model;
 
+/**
+ * Class Database
+ *
+ * @package Camcima\MySqlDiff\Model
+ */
 class Database
 {
     /**
@@ -27,8 +32,8 @@ class Database
 
     /**
      * @param string $tableName
-     *
      * @return Table
+     * @throws \RuntimeException
      */
     public function getTableByName($tableName)
     {

--- a/src/Model/DatabaseDiff.php
+++ b/src/Model/DatabaseDiff.php
@@ -2,6 +2,11 @@
 
 namespace Camcima\MySqlDiff\Model;
 
+/**
+ * Class DatabaseDiff
+ *
+ * @package Camcima\MySqlDiff\Model
+ */
 class DatabaseDiff
 {
     /**

--- a/src/Model/ForeignKey.php
+++ b/src/Model/ForeignKey.php
@@ -2,6 +2,11 @@
 
 namespace Camcima\MySqlDiff\Model;
 
+/**
+ * Class ForeignKey
+ *
+ * @package Camcima\MySqlDiff\Model
+ */
 class ForeignKey
 {
     /**

--- a/src/Model/Index.php
+++ b/src/Model/Index.php
@@ -2,6 +2,11 @@
 
 namespace Camcima\MySqlDiff\Model;
 
+/**
+ * Class Index
+ *
+ * @package Camcima\MySqlDiff\Model
+ */
 class Index
 {
     /**
@@ -72,7 +77,7 @@ class Index
     }
 
     /**
-     * @return Column[]
+     * @return IndexColumn[]
      */
     public function getIndexColumns()
     {
@@ -97,13 +102,13 @@ class Index
 
     /**
      * @param $columnName
-     *
      * @return IndexColumn
+     * @throws \RuntimeException
      */
     public function getIndexColumnByColumnName($columnName)
     {
         foreach ($this->indexColumns as $indexColumn) {
-            if ($indexColumn->getColumn()->getName() == $columnName) {
+            if ($indexColumn->getColumn()->getName() === $columnName) {
                 return $indexColumn;
             }
         }

--- a/src/Model/IndexColumn.php
+++ b/src/Model/IndexColumn.php
@@ -2,6 +2,11 @@
 
 namespace Camcima\MySqlDiff\Model;
 
+/**
+ * Class IndexColumn
+ *
+ * @package Camcima\MySqlDiff\Model
+ */
 class IndexColumn
 {
     /**

--- a/src/Model/Table.php
+++ b/src/Model/Table.php
@@ -2,6 +2,11 @@
 
 namespace Camcima\MySqlDiff\Model;
 
+/**
+ * Class Table
+ *
+ * @package Camcima\MySqlDiff\Model
+ */
 class Table
 {
     /**
@@ -48,6 +53,16 @@ class Table
      * @var string
      */
     private $engine;
+
+    /**
+     * @var string
+     */
+    private $rowFormat;
+
+    /**
+     * @var string
+     */
+    private $keyBlockSize;
 
     /**
      * @var int
@@ -155,13 +170,13 @@ class Table
 
     /**
      * @param string $columnName
-     *
      * @return Column
+     * @throws \RuntimeException
      */
     public function getColumnByName($columnName)
     {
         if (!isset($this->columns[$columnName])) {
-            throw new \RuntimeException(sprintf('Column "%s" not found in table ""!', $columnName, $this->name));
+            throw new \RuntimeException(sprintf('Column "%s" not found in table "%s"!', $columnName, $this->name));
         }
 
         return $this->columns[$columnName];
@@ -169,18 +184,18 @@ class Table
 
     /**
      * @param int $columnOrder
-     *
      * @return Column
+     * @throws \RuntimeException
      */
     public function getColumnByOrder($columnOrder)
     {
         foreach ($this->columns as $column) {
-            if ($column->getOrder() == $columnOrder) {
+            if ($column->getOrder() === $columnOrder) {
                 return $column;
             }
         }
 
-        throw new \RuntimeException(sprintf('Column order "%s" not found in table ""!', $columnOrder, $this->name));
+        throw new \RuntimeException(sprintf('Column order "%s" not found in table "%s"!', $columnOrder, $this->name));
     }
 
     /**
@@ -228,13 +243,13 @@ class Table
 
     /**
      * @param string $foreignKeyName
-     *
      * @return ForeignKey
+     * @throws \RuntimeException
      */
     public function getForeignKeyByName($foreignKeyName)
     {
         if (!isset($this->foreignKeys[$foreignKeyName])) {
-            throw new \RuntimeException(sprintf('Foreign key "%s" not found in table ""!', $foreignKeyName, $this->name));
+            throw new \RuntimeException(sprintf('Foreign key "%s" not found in table "%s"!', $foreignKeyName, $this->name));
         }
 
         return $this->foreignKeys[$foreignKeyName];
@@ -269,13 +284,13 @@ class Table
 
     /**
      * @param string $indexName
-     *
      * @return Index
+     * @throws \RuntimeException
      */
     public function getIndexByName($indexName)
     {
         if (!isset($this->indexes[$indexName])) {
-            throw new \RuntimeException(sprintf('Index "%s" not found in table ""!', $indexName, $this->name));
+            throw new \RuntimeException(sprintf('Index "%s" not found in table "%s"!', $indexName, $this->name));
         }
 
         return $this->indexes[$indexName];
@@ -305,6 +320,38 @@ class Table
     public function setEngine($engine)
     {
         $this->engine = $engine;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRowFormat()
+    {
+        return $this->rowFormat;
+    }
+
+    /**
+     * @param string $rowFormat
+     */
+    public function setRowFormat($rowFormat)
+    {
+        $this->rowFormat = $rowFormat;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKeyBlockSize()
+    {
+        return $this->keyBlockSize;
+    }
+
+    /**
+     * @param string $keyBlockSize
+     */
+    public function setKeyBlockSize($keyBlockSize)
+    {
+        $this->keyBlockSize = $keyBlockSize;
     }
 
     /**
@@ -434,6 +481,14 @@ class Table
 
         if ($this->defaultCharset) {
             $tableOptions[] = sprintf('DEFAULT CHARSET=%s', $this->defaultCharset);
+        }
+
+        if ($this->rowFormat) {
+            $tableOptions[] = sprintf('ROW_FORMAT=%s', $this->rowFormat);
+        }
+
+        if ($this->keyBlockSize) {
+            $tableOptions[] = sprintf('KEY_BLOCK_SIZE=%s', $this->keyBlockSize);
         }
 
         if ($this->comment) {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -9,6 +9,11 @@ use Camcima\MySqlDiff\Model\Index;
 use Camcima\MySqlDiff\Model\IndexColumn;
 use Camcima\MySqlDiff\Model\Table;
 
+/**
+ * Class Parser
+ *
+ * @package Camcima\MySqlDiff
+ */
 class Parser
 {
     /**
@@ -41,7 +46,8 @@ class Parser
         preg_match_all(RegExpPattern::tables(), $sqlScript, $matches);
 
         $tables = [];
-        for ($i = 0; $i < count($matches[0]); $i++) {
+        $loopCounter = count($matches[0]);
+        for ($i = 0; $i < $loopCounter; $i++) {
             $name = $matches['tableName'][$i];
             $ifNotExists = $matches['ifNotExists'][$i];
             $definition = $matches['tableDefinition'][$i];
@@ -50,6 +56,8 @@ class Parser
             $autoIncrement = $matches['autoIncrement'][$i];
             $defaultCharset = $matches['defaultCharset'][$i];
             $comment = $matches['comment'][$i];
+            $rowFormat = $matches['rowFormat'][$i];
+            $keyBlockSize = $matches['keyBlockSize'][$i];
 
             $table = new Table($name);
             $table->setDefinition(trim($definition));
@@ -73,6 +81,14 @@ class Parser
 
             if ($comment) {
                 $table->setComment(str_replace('\'\'', '\'', $comment));
+            }
+
+            if ($rowFormat) {
+                $table->setRowFormat($rowFormat);
+            }
+
+            if ($keyBlockSize) {
+                $table->setKeyBlockSize($keyBlockSize);
             }
 
             $tables[$name] = $table;
@@ -100,7 +116,8 @@ class Parser
         preg_match_all(RegExpPattern::column(), $table->getDefinition(), $matches);
 
         $lastColumn = null;
-        for ($i = 0; $i < count($matches[0]); $i++) {
+        $loopCounter = count($matches[0]);
+        for ($i = 0; $i < $loopCounter; $i++) {
             $columnName = $matches['columnName'][$i];
             $columnType = $matches['columnType'][$i];
             $intLength = $matches['intLength'][$i];
@@ -132,7 +149,7 @@ class Parser
 
             $column->setLength($this->getColumnLength($intLength, $decimalLength, $doubleLength, $floatLength, $charLength, $binaryLength, $yearLength));
             $column->setPrecision($this->getColumnPrecision($decimalPrecision, $doublePrecision, $floatPrecision));
-            $column->setNullable($nullable != 'NOT NULL');
+            $column->setNullable($nullable !== 'NOT NULL');
             $column->setAutoIncrement(!empty($autoIncrement));
 
             if (!empty($defaultValue)) {
@@ -206,7 +223,8 @@ class Parser
     {
         preg_match_all(RegExpPattern::foreignKey(), $table->getDefinition(), $matches);
 
-        for ($i = 0; $i < count($matches[0]); $i++) {
+        $loopCounter = count($matches[0]);
+        for ($i = 0; $i < $loopCounter; $i++) {
             $name = $matches['name'][$i];
             $columnName = $matches['column'][$i];
             $referenceTableName = $matches['referenceTable'][$i];
@@ -238,7 +256,8 @@ class Parser
     {
         preg_match_all(RegExpPattern::index(), $table->getDefinition(), $matches);
 
-        for ($i = 0; $i < count($matches[0]); $i++) {
+        $loopCounter = count($matches[0]);
+        for ($i = 0; $i < $loopCounter; $i++) {
             $indexName = $matches['name'][$i];
             $indexColumnNames = explode(',', str_replace('`', '', $matches['columns'][$i]));
             $indexOptions = $matches['options'][$i];
@@ -289,21 +308,26 @@ class Parser
     {
         if (!empty($intLength)) {
             return (int) $intLength;
-        } elseif (!empty($decimalLength)) {
-            return (int) $decimalLength;
-        } elseif (!empty($doubleLength)) {
-            return (int) $doubleLength;
-        } elseif (!empty($floatLength)) {
-            return (int) $floatLength;
-        } elseif (!empty($charLength)) {
-            return (int) $charLength;
-        } elseif (!empty($binaryLength)) {
-            return (int) $binaryLength;
-        } elseif (!empty($yearLength)) {
-            return (int) $yearLength;
-        } else {
-            return;
         }
+        if (!empty($decimalLength)) {
+            return (int) $decimalLength;
+        }
+        if (!empty($doubleLength)) {
+            return (int) $doubleLength;
+        }
+        if (!empty($floatLength)) {
+            return (int) $floatLength;
+        }
+        if (!empty($charLength)) {
+            return (int) $charLength;
+        }
+        if (!empty($binaryLength)) {
+            return (int) $binaryLength;
+        }
+        if (!empty($yearLength)) {
+            return (int) $yearLength;
+        }
+        return null;
     }
 
     /**
@@ -317,12 +341,13 @@ class Parser
     {
         if (!empty($decimalPrecision)) {
             return (int) $decimalPrecision;
-        } elseif (!empty($doublePrecision)) {
-            return (int) $doublePrecision;
-        } elseif (!empty($floatPrecision)) {
-            return (int) $floatPrecision;
-        } else {
-            return;
         }
+        if (!empty($doublePrecision)) {
+            return (int) $doublePrecision;
+        }
+        if (!empty($floatPrecision)) {
+            return (int) $floatPrecision;
+        }
+        return null;
     }
 }

--- a/src/RegExpPattern.php
+++ b/src/RegExpPattern.php
@@ -3,8 +3,16 @@
 namespace Camcima\MySqlDiff;
 
 
+/**
+ * Class RegExpPattern
+ *
+ * @package Camcima\MySqlDiff
+ */
 class RegExpPattern
 {
+    /**
+     * @var array
+     */
     private static $columnTypeRegExps = [
         '(?:tiny|small|medium|big)?int(?:\((?<intLength>\d+)\))?(?:\s+unsigned)?',
         'float(?:\s+unsigned)?(?:\((?<floatLength>\d+),(?<floatPrecision>\d+)\))?',
@@ -39,6 +47,10 @@ class RegExpPattern
         $pattern .= '(?:AUTO_INCREMENT\s*=\s*(?<autoIncrement>\d+))?\s*';
         $pattern .= '|';
         $pattern .= '(?:DEFAULT CHARSET\s*=\s*(?<defaultCharset>[^;\s]+))?\s*';
+        $pattern .= '|';
+        $pattern .= '(?:\s+ROW_FORMAT\s*=\s*(?<rowFormat>[^;\s]+))?\s*';
+        $pattern .= '|';
+        $pattern .= '(?:\s+KEY_BLOCK_SIZE\s*=\s*(?<keyBlockSize>[^;\s]+))?\s*';
         $pattern .= '|';
         $pattern .= '(?:COLLATE\s*=\s*.+?)?\s*';
         $pattern .= '|';

--- a/tests/fixtures/sakila_migration.sql
+++ b/tests/fixtures/sakila_migration.sql
@@ -23,7 +23,10 @@ ALTER TABLE `test2`
   ADD COLUMN `new_field` int(10) AFTER `datade`,
   ADD PRIMARY KEY (`id`,`new_field`),
   ADD UNIQUE KEY `FK__test1` (`datade`),
-  ADD CONSTRAINT `FK__test3` FOREIGN KEY (`fk`) REFERENCES `test3` (`id`);
+  ADD CONSTRAINT `FK__test3` FOREIGN KEY (`fk`) REFERENCES `test3` (`id`),
+  ROW_FORMAT=COMPRESSED,
+  KEY_BLOCK_SIZE=4,
+  COMMENT='test1';
 
 # New Tables
 

--- a/tests/fixtures/sakila_new.sql
+++ b/tests/fixtures/sakila_new.sql
@@ -170,7 +170,7 @@ DROP TABLE IF EXISTS `customer_list`;
 /*!50001 DROP VIEW IF EXISTS `customer_list`*/;
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
-/*!50001 CREATE VIEW `customer_list` AS SELECT 
+/*!50001 CREATE VIEW `customer_list` AS SELECT
  1 AS `ID`,
  1 AS `name`,
  1 AS `address`,
@@ -315,7 +315,7 @@ DROP TABLE IF EXISTS `film_list`;
 /*!50001 DROP VIEW IF EXISTS `film_list`*/;
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
-/*!50001 CREATE VIEW `film_list` AS SELECT 
+/*!50001 CREATE VIEW `film_list` AS SELECT
  1 AS `FID`,
  1 AS `title`,
  1 AS `description`,
@@ -385,7 +385,7 @@ DROP TABLE IF EXISTS `nicer_but_slower_film_list`;
 /*!50001 DROP VIEW IF EXISTS `nicer_but_slower_film_list`*/;
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
-/*!50001 CREATE VIEW `nicer_but_slower_film_list` AS SELECT 
+/*!50001 CREATE VIEW `nicer_but_slower_film_list` AS SELECT
  1 AS `FID`,
  1 AS `title`,
  1 AS `description`,
@@ -489,7 +489,7 @@ DROP TABLE IF EXISTS `sales_by_film_category`;
 /*!50001 DROP VIEW IF EXISTS `sales_by_film_category`*/;
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
-/*!50001 CREATE VIEW `sales_by_film_category` AS SELECT 
+/*!50001 CREATE VIEW `sales_by_film_category` AS SELECT
  1 AS `category`,
  1 AS `total_sales`*/;
 SET character_set_client = @saved_cs_client;
@@ -502,7 +502,7 @@ DROP TABLE IF EXISTS `sales_by_store`;
 /*!50001 DROP VIEW IF EXISTS `sales_by_store`*/;
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
-/*!50001 CREATE VIEW `sales_by_store` AS SELECT 
+/*!50001 CREATE VIEW `sales_by_store` AS SELECT
  1 AS `store`,
  1 AS `manager`,
  1 AS `total_sales`*/;
@@ -543,7 +543,7 @@ DROP TABLE IF EXISTS `staff_list`;
 /*!50001 DROP VIEW IF EXISTS `staff_list`*/;
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
-/*!50001 CREATE VIEW `staff_list` AS SELECT 
+/*!50001 CREATE VIEW `staff_list` AS SELECT
  1 AS `ID`,
  1 AS `name`,
  1 AS `address`,
@@ -605,7 +605,7 @@ CREATE TABLE `test2` (
   UNIQUE KEY `FK__test1` (`datade`),
   CONSTRAINT `FK__test3` FOREIGN KEY (`id`) REFERENCES `test` (`test1`)
   CONSTRAINT `FK__test3` FOREIGN KEY (`fk`) REFERENCES `test3` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=4 COMMENT='test1';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --


### PR DESCRIPTION
- Added ROW_FORMAT and KEY_BLOCK_SIZE to create table
- Added ROW_FORMAT, KEY_BLOCK_SIZE and COMMENT to alter table
- Added generateMigrationScriptArray that returns SQL commands as an array (generateMigrationScript is using generateMigrationScriptArray)
- Updated unit tests
- Fixed some typos, phpdoc, strict type comparison

Note: The regular expression detects the end of create table by looking for a comment. If you use SHOW CREATE TABLE instead of mysqldump, you need to append "; /* something */" or it does not recognize multiple tables. Maybe there is a note for this already. I might address this issue in the future.