### PR TITLE
Changes in decimal unsigned columns not detected

### DIFF
--- a/src/RegExpPattern.php
+++ b/src/RegExpPattern.php
@@ -18,7 +18,7 @@ class RegExpPattern
         'float(?:\s+unsigned)?(?:\((?<floatLength>\d+),(?<floatPrecision>\d+)\))?',
         'binary',
         'real',
-        'decimal\((?<decimalLength>\d+),(?<decimalPrecision>\d+)\)',
+        'decimal\((?<decimalLength>\d+),(?<decimalPrecision>\d+)\)(?:\s+unsigned)?',
         'double(?:\((?<doubleLength>\d+),(?<doublePrecision>\d+)\))?(?:\s+unsigned)?',
         'datetime',
         'date',


### PR DESCRIPTION
Modified regexp to accept unsigned decimal columns

Before the changes on decimal unsigned columns were not detected.

## Test case:
**FROM:**

```
CREATE TABLE `test2` (
  `id` int(10) NOT NULL AUTO_INCREMENT,
  `fk` int(10) NULL,
  `val` decimal(11,3) unsigned NOT NULL,
  `texto` char(60) NOT NULL DEFAULT 'default',
  `datade` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
  `new_field` int(10) NULL,
  PRIMARY KEY (`id`,`new_field`),
  KEY `FK__test1` (`fk`,`texto`),
  UNIQUE KEY `FK__test1` (`datade`),
  CONSTRAINT `FK__test3` FOREIGN KEY (`id`) REFERENCES `test` (`test1`)
  CONSTRAINT `FK__test3` FOREIGN KEY (`fk`) REFERENCES `test3` (`id`)
) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=4 COMMENT='test1';
```

**TO:**

```
CREATE TABLE `test2` (
  `id` int(10) NOT NULL AUTO_INCREMENT,
  `fk` int(10) NULL,
  `texto` char(60) NOT NULL DEFAULT 'default',
  `datade` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
  `new_field` int(10) NULL,
  PRIMARY KEY (`id`,`new_field`),
  KEY `FK__test1` (`fk`,`texto`),
  UNIQUE KEY `FK__test1` (`datade`),
  CONSTRAINT `FK__test3` FOREIGN KEY (`id`) REFERENCES `test` (`test1`)
  CONSTRAINT `FK__test3` FOREIGN KEY (`fk`) REFERENCES `test3` (`id`)
) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=4 COMMENT='test1';
```
